### PR TITLE
Updated first await call to use ConfigureAwait for all public APIs

### DIFF
--- a/BitbucketProxy.cs
+++ b/BitbucketProxy.cs
@@ -29,7 +29,7 @@ namespace AzureSourceControls
         {
             CommonUtils.ValidateNullArgument("redirectUri", redirectUri);
 
-            return await _provider.GetOAuthInfo(redirectUri);
+            return await _provider.GetOAuthInfo(redirectUri).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<OAuthV1Info> Authorize(string callbackUri, string token, string tokenSecret)
@@ -56,7 +56,7 @@ namespace AzureSourceControls
                 throw new OAuthException("Bitbucket Authorize: missing oauth_verifier query string.", HttpStatusCode.Unauthorized, callbackUri);
             }
 
-            return await _provider.Authorize(oauth_verifier, token, tokenSecret);
+            return await _provider.Authorize(oauth_verifier, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<BitbucketAccountInfo> GetAccoutInfo(string token, string tokenSecret)
@@ -64,7 +64,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("token", token);
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
-            var user = await _provider.GetAsync<BitbucketUserInfo>("GetAccoutInfo", "https://api.bitbucket.org/1.0/user/", token, tokenSecret);
+            var user = await _provider.GetAsync<BitbucketUserInfo>("GetAccoutInfo", "https://api.bitbucket.org/1.0/user/", token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
             return user.user;
         }
 
@@ -73,7 +73,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("token", token);
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
-            return await _provider.GetAsync<BitbucketRepoInfo[]>("ListRepositories", "https://api.bitbucket.org/1.0/user/repositories/", token, tokenSecret);
+            return await _provider.GetAsync<BitbucketRepoInfo[]>("ListRepositories", "https://api.bitbucket.org/1.0/user/repositories/", token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<BitbucketRepoInfo> GetRepository(string repoUrl, string token, string tokenSecret)
@@ -83,7 +83,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
             var requestUri = GetRequestUri(repoUrl);
-            return await _provider.GetAsync<BitbucketRepoInfo>("GetRepository", requestUri, token, tokenSecret);
+            return await _provider.GetAsync<BitbucketRepoInfo>("GetRepository", requestUri, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<IEnumerable<BitbucketBranchInfo>> ListBranches(string repoUrl, string token, string tokenSecret)
@@ -93,7 +93,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
             var requestUri = GetRequestUri(repoUrl, "branches");
-            var branches = await _provider.GetAsync<Dictionary<string, BitbucketBranchInfo>>("ListBranches", requestUri, token, tokenSecret);
+            var branches = await _provider.GetAsync<Dictionary<string, BitbucketBranchInfo>>("ListBranches", requestUri, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
             return branches.Select(p =>
             {
                 p.Value.name = p.Key;
@@ -108,7 +108,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
             CommonUtils.ValidateNullArgument("hookUrl", hookUrl);
 
-            var hook = await GetWebHookInfo(repoUrl, token, tokenSecret, hookUrl);
+            var hook = await GetWebHookInfo(repoUrl, token, tokenSecret, hookUrl).ConfigureAwait(continueOnCapturedContext: false);
             if (hook != null)
             {
                 if (string.Equals(hookUrl, hook.service.url, StringComparison.OrdinalIgnoreCase))
@@ -134,7 +134,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
             CommonUtils.ValidateNullArgument("hookUrl", hookUrl);
 
-            var hook = await GetWebHookInfo(repoUrl, token, tokenSecret, hookUrl);
+            var hook = await GetWebHookInfo(repoUrl, token, tokenSecret, hookUrl).ConfigureAwait(continueOnCapturedContext: false);
             if (hook != null)
             {
                 var requestUri = GetRequestUri(repoUrl, "services", hook.id);
@@ -152,7 +152,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("title", title);
             CommonUtils.ValidateNullArgument("sshKey", sshKey);
 
-            await RemoveSSHKey(repoUrl, token, tokenSecret, sshKey);
+            await RemoveSSHKey(repoUrl, token, tokenSecret, sshKey).ConfigureAwait(continueOnCapturedContext: false);
 
             var sshKeyInfo = new BitbucketSSHKeyInfo { label = title, key = sshKey };
             var requestUri = GetRequestUri(repoUrl, "deploy-keys");
@@ -166,7 +166,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
             CommonUtils.ValidateNullArgument("sshKey", sshKey);
 
-            var sshKeyInfo = await GetSSHKey(repoUrl, token, tokenSecret, sshKey);
+            var sshKeyInfo = await GetSSHKey(repoUrl, token, tokenSecret, sshKey).ConfigureAwait(continueOnCapturedContext: false);
             if (sshKeyInfo != null)
             {
                 var requestUri = GetRequestUri(repoUrl, "deploy-keys", sshKeyInfo.pk);

--- a/CodePlexProxy.cs
+++ b/CodePlexProxy.cs
@@ -26,7 +26,7 @@ namespace AzureSourceControls
         {
             CommonUtils.ValidateNullArgument("redirectUri", redirectUri);
 
-            return await _provider.GetOAuthInfo(redirectUri, scope: "project_info,test_web_hook");
+            return await _provider.GetOAuthInfo(redirectUri, scope: "project_info,test_web_hook").ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<OAuthV1Info> Authorize(string callbackUri, string token, string tokenSecret)
@@ -53,7 +53,7 @@ namespace AzureSourceControls
                 throw new OAuthException("CodePlex Authorize: missing oauth_verifier query string.", HttpStatusCode.Unauthorized, callbackUri);
             }
 
-            return await _provider.Authorize(oauth_verifier, token, tokenSecret);
+            return await _provider.Authorize(oauth_verifier, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<CodePlexAccountInfo> GetAccountInfo(string token, string tokenSecret)
@@ -62,7 +62,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
             var requestUri = String.Format("https://www.codeplex.com/api/user");
-            return await _provider.GetAsync<CodePlexAccountInfo>("GetAccountInfo", requestUri, token, tokenSecret);
+            return await _provider.GetAsync<CodePlexAccountInfo>("GetAccountInfo", requestUri, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<IEnumerable<CodePlexProjectInfo>> ListProjects(string token, string tokenSecret)
@@ -71,7 +71,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
             var requestUri = "https://www.codeplex.com/api/user/repos?expanded=true&role=coordinator";
-            var projects = await _provider.GetAsync<CodePlexProject[]>("ListProjects", requestUri, token, tokenSecret);
+            var projects = await _provider.GetAsync<CodePlexProject[]>("ListProjects", requestUri, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
             return projects.Select(p => p.Project);
         }
 
@@ -82,7 +82,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
             var requestUri = GetRequestUri(repoUrl);
-            return await _provider.GetAsync<CodePlexProjectInfo>("GetProject", requestUri, token, tokenSecret);
+            return await _provider.GetAsync<CodePlexProjectInfo>("GetProject", requestUri, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task AddWebHook(string repoUrl, string token, string tokenSecret, string hookUrl)
@@ -102,7 +102,7 @@ namespace AzureSourceControls
                 }
             };
 
-            await _provider.PatchAsJsonAsync("AddWebHook", requestUri, token, tokenSecret, projectInfo);
+            await _provider.PatchAsJsonAsync("AddWebHook", requestUri, token, tokenSecret, projectInfo).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task RemoveWebHook(string repoUrl, string token, string tokenSecret)
@@ -120,7 +120,7 @@ namespace AzureSourceControls
                 }
             };
 
-            await _provider.PatchAsJsonAsync("RemoveWebHook", requestUri, token, tokenSecret, projectInfo);
+            await _provider.PatchAsJsonAsync("RemoveWebHook", requestUri, token, tokenSecret, projectInfo).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         static private string GetRequestUri(string repoUrl)

--- a/DropboxProxy.cs
+++ b/DropboxProxy.cs
@@ -26,7 +26,7 @@ namespace AzureSourceControls
         {
             CommonUtils.ValidateNullArgument("redirectUri", redirectUri);
 
-            return await _provider.GetOAuthInfo(redirectUri);
+            return await _provider.GetOAuthInfo(redirectUri).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<OAuthV1Info> Authorize(string callbackUri, string token, string tokenSecret)
@@ -53,7 +53,7 @@ namespace AzureSourceControls
                 throw new OAuthException("Dropbox Authorize: missing uid query string.", HttpStatusCode.Unauthorized, callbackUri);
             }
 
-            return await _provider.Authorize(uid, token, tokenSecret);
+            return await _provider.Authorize(uid, token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<DropboxAccountInfo> GetAccountInfo(string token, string tokenSecret)
@@ -61,7 +61,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("token", token);
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
 
-            return await _provider.GetAsync<DropboxAccountInfo>("GetAccountInfo", "https://api.dropbox.com/1/account/info", token, tokenSecret);
+            return await _provider.GetAsync<DropboxAccountInfo>("GetAccountInfo", "https://api.dropbox.com/1/account/info", token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         public async Task<IEnumerable<string>> ListFolders(string token, string tokenSecret, string appName)
@@ -70,7 +70,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("tokenSecret", tokenSecret);
             CommonUtils.ValidateNullArgument("appName", appName);
 
-            var info = await _provider.GetAsync<DropboxMetadataInfo>("ListFolders", "https://api.dropbox.com/1/metadata/sandbox", token, tokenSecret);
+            var info = await _provider.GetAsync<DropboxMetadataInfo>("ListFolders", "https://api.dropbox.com/1/metadata/sandbox", token, tokenSecret).ConfigureAwait(continueOnCapturedContext: false);
             return info.contents.Where(c => c.is_dir)
                 .Select(c => String.Format("https://www.dropbox.com/home/Apps/{0}/{1}", appName, c.path.Trim('/')));
         }
@@ -79,7 +79,7 @@ namespace AzureSourceControls
         {
             path = '/' + path.Trim('/').Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Last();
 
-            var folders = await ListFolders(token, tokenSecret, "app");
+            var folders = await ListFolders(token, tokenSecret, "app").ConfigureAwait(continueOnCapturedContext: false);
             if (!FolderExists(folders, path))
             {
                 var requestUri = String.Format("https://api.dropbox.com/1/fileops/create_folder?root=sandbox&path={0}", path);

--- a/GitHubProxy.cs
+++ b/GitHubProxy.cs
@@ -83,7 +83,7 @@ namespace AzureSourceControls
 
             using (var client = CreateHttpClient())
             {
-                using (var response = await client.PostAsync("https://github.com/login/oauth/access_token", content))
+                using (var response = await client.PostAsync("https://github.com/login/oauth/access_token", content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var info = await ProcessResponse<OAuthInfo>("Authorize", response);
                     return info.access_token;
@@ -101,7 +101,7 @@ namespace AzureSourceControls
                 ListOrgRepos(accessToken)
             };
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(continueOnCapturedContext: false);
 
             return CommonUtils.ConcatEnumerable(tasks.Select(t => t.Result));
         }
@@ -113,7 +113,7 @@ namespace AzureSourceControls
             var requestUri = "https://api.github.com/user";
             using (var client = CreateGitHubClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<GitHubAccountInfo>("GetAccountInfo", response);
                 }
@@ -128,7 +128,7 @@ namespace AzureSourceControls
             var requestUri = GetRequestUri(repoUrl);
             using (var client = CreateGitHubClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<GitHubRepoInfo>("GetRepository", response);
                 }
@@ -143,7 +143,7 @@ namespace AzureSourceControls
             var requestUri = GetRequestUri(repoUrl, "branches");
             using (var client = CreateGitHubClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<IEnumerable<GitHubBranchInfo>>("ListBranches", response);
                 }
@@ -181,7 +181,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("accessToken", accessToken);
             CommonUtils.ValidateNullArgument("hookUrl", hookUrl);
 
-            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl);
+            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl).ConfigureAwait(continueOnCapturedContext: false);
             string id = null;
             if (hook != null)
             {
@@ -224,7 +224,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("accessToken", accessToken);
             CommonUtils.ValidateNullArgument("hookUrl", hookUrl);
 
-            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl);
+            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl).ConfigureAwait(continueOnCapturedContext: false);
             if (hook == null)
             {
                 return false;
@@ -248,7 +248,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("sshKey", sshKey);
 
             // GitHub: Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
-            await RemoveSSHKey(repoUrl, accessToken, sshKey);
+            await RemoveSSHKey(repoUrl, accessToken, sshKey).ConfigureAwait(continueOnCapturedContext: false);
 
             var sshKeyInfo = new GitHubSSHKeyInfo { title = title, key = sshKey };
             var requestUri = GetRequestUri(repoUrl, "keys");
@@ -267,7 +267,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("accessToken", accessToken);
             CommonUtils.ValidateNullArgument("sshKey", sshKey);
 
-            var sshKeyInfo = await GetSSHKey(repoUrl, accessToken, sshKey);
+            var sshKeyInfo = await GetSSHKey(repoUrl, accessToken, sshKey).ConfigureAwait(continueOnCapturedContext: false);
             if (sshKeyInfo == null)
             {
                 return false;

--- a/GitHubProxy.cs
+++ b/GitHubProxy.cs
@@ -250,7 +250,7 @@ namespace AzureSourceControls
             // GitHub: Deploy keys are immutable. If you need to update a key, remove the key and create a new one instead.
             await RemoveSSHKey(repoUrl, accessToken, sshKey).ConfigureAwait(continueOnCapturedContext: false);
 
-            var sshKeyInfo = new GitHubSSHKeyInfo { title = title, key = sshKey };
+            var sshKeyInfo = new GitHubSSHKeyInfo { title = title, key = sshKey, read_only = true };
             var requestUri = GetRequestUri(repoUrl, "keys");
             using (var client = CreateGitHubClient(accessToken))
             {
@@ -305,8 +305,8 @@ namespace AzureSourceControls
             }
 
             return String.Equals(
-                src.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)[1], 
-                dst.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)[1]); 
+                src.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)[1],
+                dst.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)[1]);
         }
 
         private async Task<GitHubHookInfo> GetWebHookInfo(string repoUrl, string accessToken, string hookUrl)
@@ -619,6 +619,7 @@ namespace AzureSourceControls
             public string id { get; set; }
             public string title { get; set; }
             public string key { get; set; }
+            public bool read_only { get; set; }
         }
 
         public class OAuthInfo

--- a/OAuthV1Provider.cs
+++ b/OAuthV1Provider.cs
@@ -62,7 +62,7 @@ namespace AzureSourceControls
                     requestUri: OAuthRequestTokenUri,
                     redirectUri: redirectUri,
                     scope: scope);
-                using (var response = await client.PostAsync(OAuthRequestTokenUri, null))
+                using (var response = await client.PostAsync(OAuthRequestTokenUri, null).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     string content = null;
                     if (response.Content != null)
@@ -112,7 +112,7 @@ namespace AzureSourceControls
                     token: token, 
                     tokenSecret: tokenSecret,
                     verifier: verifier);
-                using (var response = await client.PostAsync(OAuthAccessTokenUri, null))
+                using (var response = await client.PostAsync(OAuthAccessTokenUri, null).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     string content = null;
                     if (response.Content != null)
@@ -156,7 +156,7 @@ namespace AzureSourceControls
                     requestUri,
                     token: token,
                     tokenSecret: tokenSecret);
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<T>(operation, response);
                 }
@@ -174,7 +174,7 @@ namespace AzureSourceControls
                     requestUri,
                     token: token,
                     tokenSecret: tokenSecret);
-                using (var response = await client.PatchAsJsonAsync(requestUri, value))
+                using (var response = await client.PatchAsJsonAsync(requestUri, value).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessEmptyResponse(operation, response);
                 }
@@ -193,7 +193,7 @@ namespace AzureSourceControls
                     token: token,
                     tokenSecret: tokenSecret);
 
-                using (var response = await client.PostAsJsonAsync(requestUri, value))
+                using (var response = await client.PostAsJsonAsync(requestUri, value).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessEmptyResponse(operation, response);
                 }
@@ -212,7 +212,7 @@ namespace AzureSourceControls
                     token: token,
                     tokenSecret: tokenSecret);
 
-                using (var response = await client.PostAsync(requestUri, content))
+                using (var response = await client.PostAsync(requestUri, content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessEmptyResponse(operation, response);
                 }
@@ -231,7 +231,7 @@ namespace AzureSourceControls
                     token: token,
                     tokenSecret: tokenSecret);
 
-                using (var response = await client.PutAsJsonAsync(requestUri, value))
+                using (var response = await client.PutAsJsonAsync(requestUri, value).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessEmptyResponse(operation, response);
                 }
@@ -250,7 +250,7 @@ namespace AzureSourceControls
                     token: token,
                     tokenSecret: tokenSecret);
 
-                using (var response = await client.DeleteAsync(requestUri))
+                using (var response = await client.DeleteAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessEmptyResponse(operation, response);
                 }

--- a/OneDriveProxy.cs
+++ b/OneDriveProxy.cs
@@ -89,7 +89,7 @@ namespace AzureSourceControls
             content.Headers.ContentType = new MediaTypeHeaderValue(Constants.FormUrlEncodedMediaType);
             using (var client = CreateHttpClient())
             {
-                using (var response = await client.PostAsync("https://login.live.com/oauth20_token.srf", content))
+                using (var response = await client.PostAsync("https://login.live.com/oauth20_token.srf", content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var info = await ProcessOAuthResponse("Authorize", response);
                     info.redirect_uri = redirectUri.AbsoluteUri;
@@ -112,7 +112,7 @@ namespace AzureSourceControls
             content.Headers.ContentType = new MediaTypeHeaderValue(Constants.FormUrlEncodedMediaType);
             using (var client = CreateHttpClient())
             {
-                using (var response = await client.PostAsync("https://login.live.com/oauth20_token.srf", content))
+                using (var response = await client.PostAsync("https://login.live.com/oauth20_token.srf", content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var info = await ProcessOAuthResponse("Authorize", response);
                     info.redirect_uri = redirectUri;
@@ -129,7 +129,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://apis.live.net/v5.0/me");
             using (var client = CreateHttpClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<LiveAccountInfo>("GetAccountInfo", response);
                 }
@@ -143,7 +143,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://api.onedrive.com/v1.0/drive/special/approot/children");
             using (var client = CreateHttpClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var items = await ProcessResponse<OneDriveItemCollection>("ListFolders", response);
                     return items.value;
@@ -162,7 +162,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://api.onedrive.com/v1.0/drive/special/approot/children");
             using (var client = CreateHttpClient(accessToken))
             {
-                using (var response = await client.PostAsync(requestUri, content))
+                using (var response = await client.PostAsync(requestUri, content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     if (response.StatusCode == HttpStatusCode.Conflict)
                     {
@@ -183,7 +183,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://api.onedrive.com/v1.0/drive/special/approot:/{0}", path);
             using (var client = CreateHttpClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<OneDriveItem>("GetFolder", response);
                 }
@@ -198,7 +198,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://api.onedrive.com/v1.0/drive/special/approot:/{0}", path);
             using (var client = CreateHttpClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<OneDriveItem>("GetFile", response);
                 }
@@ -215,7 +215,7 @@ namespace AzureSourceControls
             requestUri = await GetItemUri(accessToken, requestUri) + "/content";
             using (var client = CreateHttpClient(accessToken))
             {
-                var response = await client.GetAsync(requestUri);
+                var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false);
                 return (StreamContent)response.Content;
             }
         }
@@ -244,7 +244,7 @@ namespace AzureSourceControls
                         uri = String.Format("{0}?token={1}", requestUri, next);
                     }
 
-                    using (var response = await client.GetAsync(uri))
+                    using (var response = await client.GetAsync(uri).ConfigureAwait(continueOnCapturedContext: false))
                     {
                         changes = await ProcessResponse<Dictionary<string, object>>("GetChanges", response);
                     }

--- a/OneDriveProxy.cs
+++ b/OneDriveProxy.cs
@@ -40,7 +40,7 @@ namespace AzureSourceControls
             {
                 strb.AppendFormat("&redirect_uri={0}", WebUtility.UrlEncode(redirectUri));
             }
-            strb.AppendFormat("&scope={0}", WebUtility.UrlEncode("onedrive.appfolder wl.basic wl.offline_access"));
+            strb.AppendFormat("&scope={0}", WebUtility.UrlEncode("onedrive.appfolder wl.basic wl.offline_access wl.emails"));
             strb.Append("&response_type=code");
             strb.AppendFormat("&state={0}", WebUtility.UrlEncode(state ?? String.Empty));
 
@@ -463,6 +463,7 @@ namespace AzureSourceControls
             public string gender { get; set; }
             public string locale { get; set; }
             public DateTime updated_time { get; set; }
+            public Dictionary<string, string> emails { get; set; }
         }
 
         public class OneDriveItemCollection

--- a/TfsProxy.cs
+++ b/TfsProxy.cs
@@ -82,7 +82,7 @@ namespace AzureSourceControls
 
             using (var client = CreateHttpClient())
             {
-                using (var response = await client.PostAsync("https://app.vssps.visualstudio.com/oauth2/token", content))
+                using (var response = await client.PostAsync("https://app.vssps.visualstudio.com/oauth2/token", content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<OAuthInfo>("Authorize", response);
                 }
@@ -100,7 +100,7 @@ namespace AzureSourceControls
 
             using (var client = CreateHttpClient())
             {
-                using (var response = await client.PostAsync("https://app.vssps.visualstudio.com/oauth2/token", content))
+                using (var response = await client.PostAsync("https://app.vssps.visualstudio.com/oauth2/token", content).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<OAuthInfo>("RefreshToken", response);
                 }
@@ -133,7 +133,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://app.vssps.visualstudio.com/_apis/accounts?api-version={0}", ApiVersion);
             using (var client = CreateTfsClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var result = await ProcessResponse<TfsResult<TfsAccountInfo>>("ListAccounts", response);
                     return result.value;
@@ -145,7 +145,7 @@ namespace AzureSourceControls
         {
             CommonUtils.ValidateNullArgument("accessToken", accessToken);
 
-            var accounts = await ListAccounts(accessToken);
+            var accounts = await ListAccounts(accessToken).ConfigureAwait(continueOnCapturedContext: false);
             var tasks = accounts.Select(account => ListRepositories(account.accountName, accessToken));
             var result = await Task.WhenAll(tasks);
             return result.SelectMany(repo => repo).ToArray();
@@ -159,7 +159,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("https://{0}.VisualStudio.com/DefaultCollection/_apis/git/repositories?api-version={1}", accountName, ApiVersion);
             using (var client = CreateTfsClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var result = await ProcessResponse<TfsResult<TfsRepositoryInfo>>("ListRepositories", response);
                     return result.value;
@@ -175,7 +175,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("{0}?api-version={1}", repoUrl, ApiVersion);
             using (var client = CreateTfsClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     return await ProcessResponse<TfsRepositoryInfo>("GetRepository", response);
                 }
@@ -190,7 +190,7 @@ namespace AzureSourceControls
             var requestUri = String.Format("{0}/refs?api-version={1}", repoUrl, ApiVersion);
             using (var client = CreateTfsClient(accessToken))
             {
-                using (var response = await client.GetAsync(requestUri))
+                using (var response = await client.GetAsync(requestUri).ConfigureAwait(continueOnCapturedContext: false))
                 {
                     var result = await ProcessResponse<TfsResult<TfsBranchInfo>>("ListBranches", response);
                     return result.value;
@@ -210,7 +210,7 @@ namespace AzureSourceControls
             var removeWebHook = RemoveWebHook(repoUrl, accessToken, hookUrl);
             var getRository = GetRepository(repoUrl, accessToken);
 
-            await Task.WhenAll((Task)removeWebHook, getRository);
+            await Task.WhenAll((Task)removeWebHook, getRository).ConfigureAwait(continueOnCapturedContext: false);
 
             var repository = getRository.Result;
             var hook = new TfsWebHookInfo();
@@ -245,7 +245,7 @@ namespace AzureSourceControls
             CommonUtils.ValidateNullArgument("accessToken", accessToken);
             CommonUtils.ValidateNullArgument("hookUrl", hookUrl);
 
-            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl);
+            var hook = await GetWebHookInfo(repoUrl, accessToken, hookUrl).ConfigureAwait(continueOnCapturedContext: false);
             if (hook == null)
             {
                 return false;


### PR DESCRIPTION
Updated first await call to use ConfigureAwait for all public APIs.

To avoid deadlock if caller it is not using async-await pattern, and relying on its main thread.
